### PR TITLE
Persistently layered methods

### DIFF
--- a/Layers.js
+++ b/Layers.js
@@ -300,6 +300,9 @@ function makeSlotLayerAwareWithNormalLookup(
       proceedStack.pop()
     };
   };
+  Object.defineProperty(wrapped_function, 'name', {
+    value: 'layered ' + baseValue.name
+  });
   wrapped_function.isLayerAware = true;
   // this is more declarative outside of COP context
   wrapped_function.isContextJSWrapper = true;

--- a/Layers.js
+++ b/Layers.js
@@ -290,7 +290,7 @@ function pvtMakeFunctionOrPropertyLayerAware(obj, slotName, baseValue, type, isH
 
 function makeSlotLayerAwareWithNormalLookup(
     obj, slotName, baseValue, type, isHidden) {
-  var wrapped_function = function() {
+  let wrapped_function = function() {
     var composition =
         new PartialLayerComposition(this, obj, slotName, baseValue, type);
     proceedStack.push(composition);
@@ -315,7 +315,12 @@ function makeSlotLayerAwareWithNormalLookup(
   } else if (type == "setter") {
     Object.defineProperty(obj, slotName, {set: wrapped_function});
   } else {
-    obj[slotName] = wrapped_function;
+    Object.defineProperty(obj, slotName, {
+      get() { return wrapped_function; },
+      set(newFunction) {
+        makeSlotLayerAwareWithNormalLookup(this, slotName, newFunction);
+      }
+    });
   }
 };
 
@@ -382,7 +387,11 @@ function makeFunctionLayerUnaware(base_obj, function_name) {
   if (prevFunction instanceof Function) {
     prevFunction.originalFunction = originalFunction
   } else {
-    base_obj[function_name] = originalFunction
+    // need to use defineProperty because the setter keeps the function wrapped
+    Object.defineProperty(base_obj, function_name, {
+      value: originalFunction,
+      configurable: true
+    });
   }
 };
 

--- a/Layers.js
+++ b/Layers.js
@@ -300,9 +300,6 @@ function makeSlotLayerAwareWithNormalLookup(
       proceedStack.pop()
     };
   };
-  Object.defineProperty(wrapped_function, 'name', {
-    value: 'layered ' + baseValue.name
-  });
   wrapped_function.isLayerAware = true;
   // this is more declarative outside of COP context
   wrapped_function.isContextJSWrapper = true;

--- a/tests/Layers-test.js
+++ b/tests/Layers-test.js
@@ -1127,7 +1127,7 @@ describe('contextjs', function () {
             assert.equal(o2.a, 7, "layer getter broken after activation for o2");
         });
 
-        it('can provide a getter in the class for for an existing property', function() {
+        it('can provide a getter in the class for an existing property', function() {
             class Example {
                 constructor() {
                     this.a = 0;

--- a/tests/Layers-test.js
+++ b/tests/Layers-test.js
@@ -1029,7 +1029,9 @@ describe('contextjs', function () {
             const layer1 = new Layer().refineClass(Example, {
                 m() { return proceed() + 1 }
             });
-            Example.prototype.m = function () { return 2 }
+            Object.assign(Example.prototype, {
+                m() { return 2 }
+            });
             // then
             assert.equal(new Example().m(), 2, 'new method definition should apply');
             withLayers([layer1], () => assert.equal(new Example().m(), 3,

--- a/tests/Layers-test.js
+++ b/tests/Layers-test.js
@@ -1029,9 +1029,7 @@ describe('contextjs', function () {
             const layer1 = new Layer().refineClass(Example, {
                 m() { return proceed() + 1 }
             });
-            Object.assign(Example.prototype, {
-                m() { return 2 }
-            });
+            Example.prototype.m = function () { return 2 }
             // then
             assert.equal(new Example().m(), 2, 'new method definition should apply');
             withLayers([layer1], () => assert.equal(new Example().m(), 3,


### PR DESCRIPTION
An object's methods stay layer aware (wrapped) when they are overwritten by assignment to the object's property as in `object.method = function newImplementation() {}`.

Fixes #34.
